### PR TITLE
Username and password length constraints

### DIFF
--- a/code/HabitTracker/app/src/main/java/com/example/habittracker/activities/LoginActivity.java
+++ b/code/HabitTracker/app/src/main/java/com/example/habittracker/activities/LoginActivity.java
@@ -149,6 +149,11 @@ public class LoginActivity extends AppCompatActivity {
     public void loginPressed(View view) throws InvalidKeySpecException, NoSuchAlgorithmException {
         String username = usernameField.getText().toString();
 
+        if (username.length() == 0) {
+            Toast.makeText(LoginActivity.this, "Username cannot be empty!", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
         DatabaseManager db = DatabaseManager.get();
 
         db.userExists(username, new UserExistsCallback() {
@@ -207,6 +212,20 @@ public class LoginActivity extends AppCompatActivity {
         //DatabaseManager.get().getUsersColName()
 
         String username = usernameField.getText().toString();
+
+        if (username.length() == 0) {
+            Toast.makeText(LoginActivity.this, "Username cannot be empty!", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (passwordField.getText().toString().length() < 6) {
+            Toast.makeText(LoginActivity.this, "Password must be at least 6 characters long!", Toast.LENGTH_SHORT).show();
+            return;
+        }
+        if (username.equals(passwordField.getText().toString())) {
+            Toast.makeText(LoginActivity.this, "Username cannot be identical to the password!", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
         String hashedPassword = generateStrongPasswordHash(passwordField.getText().toString());
 
         DatabaseManager db = DatabaseManager.get();

--- a/code/HabitTracker/app/src/main/res/layout/activity_login.xml
+++ b/code/HabitTracker/app/src/main/res/layout/activity_login.xml
@@ -46,6 +46,7 @@
                 android:ems="10"
                 android:hint="Username"
                 android:inputType="textPersonName"
+                android:maxLength="100"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent" />
 
@@ -57,6 +58,7 @@
                 android:ems="10"
                 android:hint="Password"
                 android:inputType="textPassword"
+                android:maxLength="100"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent" />
 


### PR DESCRIPTION
Enforce a non-empty username and a password at least 6 characters long. Both fields now have a max of 100 characters.